### PR TITLE
Add cosinor plotting script and ignore artifacts directory (remove binary image)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 data/**
+artifacts/**
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/scripts/plot_cosinor_fits.py
+++ b/scripts/plot_cosinor_fits.py
@@ -1,0 +1,83 @@
+"""Plot cosinor fitted curves for consecutive 24-hour periods."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+def compute_cosinor_curve(time_hours: np.ndarray, mesor: float, amplitude: float, phase: float) -> np.ndarray:
+    """Compute the cosinor fitted curve for a 24-hour period."""
+    angular_frequency = 2 * np.pi / 24
+    return mesor + amplitude * np.cos(angular_frequency * time_hours + phase)
+
+
+def plot_consecutive_cosinor_fits(
+    data: pd.DataFrame,
+    start_index: int,
+    periods: int,
+    output_path: Path,
+) -> None:
+    """Plot cosinor fits for a consecutive block of days."""
+    data = data.sort_values(["record_date", "record_num"]).reset_index(drop=True)
+    subset = data.iloc[start_index : start_index + periods]
+
+    time_hours = np.linspace(0, 24, 240)
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    for _, row in subset.iterrows():
+        fitted = compute_cosinor_curve(time_hours, row["M"], row["A"], row["phi"])
+        label = f"{row['record_date']} (#{int(row['record_num'])})"
+        ax.plot(time_hours, fitted, label=label, linewidth=1.5, alpha=0.85)
+
+    ax.set_xlabel("Time (hours)")
+    ax.set_ylabel("Fitted value")
+    ax.set_title("Cosinor fitted curves (10 consecutive 24-hour periods)")
+    ax.set_xlim(0, 24)
+    ax.grid(True, alpha=0.3)
+    ax.legend(fontsize=8, ncol=2, frameon=False)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=200)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plot cosinor fitted curves for 10 consecutive periods.")
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        default=Path("data_samples/M0142_cosinor_features.csv"),
+        help="Path to the cosinor features CSV file.",
+    )
+    parser.add_argument(
+        "--start",
+        type=int,
+        default=0,
+        help="Start index for consecutive periods.",
+    )
+    parser.add_argument(
+        "--periods",
+        type=int,
+        default=10,
+        help="Number of consecutive periods to plot.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts/cosinor_fits.png"),
+        help="Output path for the generated plot.",
+    )
+    args = parser.parse_args()
+
+    data = pd.read_csv(args.csv)
+    plot_consecutive_cosinor_fits(data, args.start, args.periods, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a small utility to visualize cosinor-fitted 24-hour curves for consecutive days. 
- Make it easy to inspect fitted curves for a single subject by plotting multiple periods on one axis. 
- Prevent committing generated binary artifacts into the repository to avoid PR errors about binary files. 

### Description
- Add `scripts/plot_cosinor_fits.py` which implements `compute_cosinor_curve`, `plot_consecutive_cosinor_fits`, and a CLI `main` to read a CSV and write a plot. 
- The plotting function sorts input rows, builds a 0–24 hour `time_hours` grid, computes fitted curves from `M`, `A`, and `phi`, and saves the result to the configured output path. 
- Remove the committed binary `artifacts/cosinor_fits.png` from version control with `git rm`. 
- Update `.gitignore` to include `artifacts/**` so generated images are not tracked going forward. 

### Testing
- Ran `python scripts/plot_cosinor_fits.py` during initial development which completed and generated `artifacts/cosinor_fits.png` successfully. 
- No unit tests or CI jobs were added for this change. 
- The cleanup commit that removed the PNG and updated `.gitignore` did not trigger additional automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521b73d6ec8324b2e78bbbc67b93cd)